### PR TITLE
Fixed .gitignore file omitting target catalog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Created by https://www.toptal.com/developers/gitignore/api/java,intellij
-# Edit at https://www.toptal.com/developers/gitignore?templates=java,intellij
+# Created by https://www.toptal.com/developers/gitignore/api/java,maven,intellij
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,maven,intellij
 
 ### Intellij ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
@@ -140,4 +140,23 @@ fabric.properties
 hs_err_pid*
 replay_pid*
 
-# End of https://www.toptal.com/developers/gitignore/api/java,intellij
+### Maven ###
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# End of https://www.toptal.com/developers/gitignore/api/java,maven,intellij


### PR DESCRIPTION
### Description
Fixed `target` folder not being ignored by git.

### Motivation
`target` and nested folders should not be on the repo.

### Changes introduced by this PR
Changed `.gitingore` file only, added `#maven` section.

### Testing
`target` folder is no longer included in commits.