### PR TITLE
implement feature remove account

### DIFF
--- a/src/main/java/org/klodnicki/command/RemoveAccount.java
+++ b/src/main/java/org/klodnicki/command/RemoveAccount.java
@@ -1,0 +1,22 @@
+package org.klodnicki.command;
+
+import org.klodnicki.controller.AccountController;
+
+public class RemoveAccount implements MenuCommand {
+
+    public RemoveAccount(AccountController accountController) {
+        this.accountController = accountController;
+    }
+
+    private final AccountController accountController;
+
+    @Override
+    public String getName() {
+        return "remove account";
+    }
+
+    @Override
+    public void execute() {
+        accountController.removeAccount();
+    }
+}

--- a/src/main/java/org/klodnicki/controller/AccountController.java
+++ b/src/main/java/org/klodnicki/controller/AccountController.java
@@ -7,7 +7,6 @@ public class AccountController {
     private final AccountService accountService = new AccountService();
     private final MenuController menuController;
 
-    private static final String UNKNOWN_COMMAND = "Unknown command.";
     private static final String CREATE_INFO = "In order to create an account, please type the following information.";
     private static final String FIRST_NAME = "First name:";
     private static final String SECOND_NAME = "Second name:";
@@ -23,6 +22,7 @@ public class AccountController {
             "Be aware that this action cannot be rollback. ";
     private static final String REMOVE_ACCOUNT = "Enter pesel of the account which you want to delete.";
     private static final String ASK_FOR_CONFIRMATION = "Are you sure you want to delete this account? Enter yes or no";
+    private static final String SUCCESS_ACCOUNT_REMOVED = "Success! An account has been removed!";
 
 
     public AccountController(MenuController menuController) {
@@ -66,20 +66,16 @@ public class AccountController {
         String pesel = menuController.displayOnMenuAndAskForInput(REMOVE_ACCOUNT);
         String responseConfirmation = menuController.displayOnMenuAndAskForInput(ASK_FOR_CONFIRMATION);
 
-        if (responseConfirmation.equalsIgnoreCase("no")) {
+        if (!responseConfirmation.equalsIgnoreCase("yes")) {
             menuController.displayOnMenu(ABORT_OPERATION);
             return;
         }
-        if (responseConfirmation.equalsIgnoreCase("yes")) {
 
-            try {
-                accountService.removeAccount(pesel);
-            } catch (NotFoundInDatabaseException e) {
-                menuController.displayOnMenu(e.getMessage());
-            }
-
-        } else {
-            menuController.displayOnMenu(UNKNOWN_COMMAND);
+        try {
+            accountService.removeAccount(pesel);
+        } catch (NotFoundInDatabaseException e) {
+            menuController.displayOnMenu(e.getMessage());
         }
+        menuController.displayOnMenu(SUCCESS_ACCOUNT_REMOVED);
     }
 }

--- a/src/main/java/org/klodnicki/controller/AccountController.java
+++ b/src/main/java/org/klodnicki/controller/AccountController.java
@@ -7,6 +7,7 @@ public class AccountController {
     private final AccountService accountService = new AccountService();
     private final MenuController menuController;
 
+    private static final String UNKNOWN_COMMAND = "Unknown command.";
     private static final String CREATE_INFO = "In order to create an account, please type the following information.";
     private static final String FIRST_NAME = "First name:";
     private static final String SECOND_NAME = "Second name:";
@@ -17,8 +18,11 @@ public class AccountController {
     private static final String ADDRESS = "Address:";
     private static final String ABORT_OPERATION = "An operation has been canceled.";
     private static final String SUCCESS_ACCOUNT_CREATION = "Success! An account has been created!";
-
     private static final String LIST_OF_ACCOUNTS = "Below you will find list of all accounts in database:";
+    private static final String REMOVE_WARNING = "WARNING!!! You are going to remove an account. " +
+            "Be aware that this action cannot be rollback. ";
+    private static final String REMOVE_ACCOUNT = "Enter pesel of the account which you want to delete.";
+    private static final String ASK_FOR_CONFIRMATION = "Are you sure you want to delete this account? Enter yes or no";
 
 
     public AccountController(MenuController menuController) {
@@ -53,6 +57,29 @@ public class AccountController {
             menuController.displayOnMenu(accountService.prepareListOfAllAccounts());
         } catch (NotFoundInDatabaseException e) {
             menuController.displayOnMenu(e.getMessage());
+        }
+    }
+
+    public void removeAccount() {
+        menuController.displayOnMenu(REMOVE_WARNING);
+        showAccounts();
+        String pesel = menuController.displayOnMenuAndAskForInput(REMOVE_ACCOUNT);
+        String responseConfirmation = menuController.displayOnMenuAndAskForInput(ASK_FOR_CONFIRMATION);
+
+        if (responseConfirmation.equalsIgnoreCase("no")) {
+            menuController.displayOnMenu(ABORT_OPERATION);
+            return;
+        }
+        if (responseConfirmation.equalsIgnoreCase("yes")) {
+
+            try {
+                accountService.removeAccount(pesel);
+            } catch (NotFoundInDatabaseException e) {
+                menuController.displayOnMenu(e.getMessage());
+            }
+
+        } else {
+            menuController.displayOnMenu(UNKNOWN_COMMAND);
         }
     }
 }

--- a/src/main/java/org/klodnicki/entity/Account.java
+++ b/src/main/java/org/klodnicki/entity/Account.java
@@ -22,7 +22,7 @@ public class Account {
     private String secondName;
     @Column(nullable = false, name = "last_name")
     private String lastName;
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String pesel;
     @Column(name = "phone_number")
     private String phoneNumber;

--- a/src/main/java/org/klodnicki/repository/AccountRepository.java
+++ b/src/main/java/org/klodnicki/repository/AccountRepository.java
@@ -42,5 +42,20 @@ public class AccountRepository {
         entityManager.getTransaction().commit();
     }
 
+    public Optional<Account> accountExist(String pesel) {
+        String hqlQuery = "FROM Account a WHERE a.pesel = :pesel";
+        TypedQuery<Account> query = entityManager.createQuery(hqlQuery, Account.class);
+        query.setParameter("pesel", pesel);
+
+        Account singleResult;
+
+        try {
+            singleResult = query.getSingleResult();
+        } catch (NoResultException e) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(singleResult);
+    }
 
 }

--- a/src/main/java/org/klodnicki/repository/AccountRepository.java
+++ b/src/main/java/org/klodnicki/repository/AccountRepository.java
@@ -42,7 +42,7 @@ public class AccountRepository {
         entityManager.getTransaction().commit();
     }
 
-    public Optional<Account> accountExist(String pesel) {
+    public Optional<Account> findAccountByPesel(String pesel) {
         String hqlQuery = "FROM Account a WHERE a.pesel = :pesel";
         TypedQuery<Account> query = entityManager.createQuery(hqlQuery, Account.class);
         query.setParameter("pesel", pesel);

--- a/src/main/java/org/klodnicki/repository/AccountRepository.java
+++ b/src/main/java/org/klodnicki/repository/AccountRepository.java
@@ -1,10 +1,10 @@
 package org.klodnicki.repository;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.TypedQuery;
+import jakarta.persistence.*;
 import org.klodnicki.entity.Account;
 
 import java.util.List;
+import java.util.Optional;
 
 public class AccountRepository {
     private final EntityManager entityManager = HibernateUtil.getSessionFactory().createEntityManager();
@@ -31,4 +31,16 @@ public class AccountRepository {
 
         return query.getResultList();
     }
+
+    public void removeAccount(String pesel) {
+
+        entityManager.getTransaction().begin();
+        String hqlQuery = "DELETE FROM Account a WHERE a.pesel = :pesel";
+        Query query = entityManager.createQuery(hqlQuery);
+        query.setParameter("pesel", pesel);
+        query.executeUpdate();
+        entityManager.getTransaction().commit();
+    }
+
+
 }

--- a/src/main/java/org/klodnicki/service/AccountService.java
+++ b/src/main/java/org/klodnicki/service/AccountService.java
@@ -54,6 +54,6 @@ public class AccountService {
     }
 
     private boolean accountExist(String pesel) {
-        return accountRepository.accountExist(pesel).isPresent();
+        return accountRepository.findAccountByPesel(pesel).isPresent();
     }
 }

--- a/src/main/java/org/klodnicki/service/AccountService.java
+++ b/src/main/java/org/klodnicki/service/AccountService.java
@@ -45,4 +45,15 @@ public class AccountService {
     private List<Account> getAllAccountsFromDatabase() {
         return accountRepository.findAllAccounts();
     }
+
+    public void removeAccount(String pesel) throws NotFoundInDatabaseException {
+        if (!accountExist(pesel)) {
+            throw new NotFoundInDatabaseException(Account.class);
+        }
+        accountRepository.removeAccount(pesel);
+    }
+
+    private boolean accountExist(String pesel) {
+        return accountRepository.accountExist(pesel).isPresent();
+    }
 }

--- a/src/main/java/org/klodnicki/service/MenuService.java
+++ b/src/main/java/org/klodnicki/service/MenuService.java
@@ -17,6 +17,7 @@ public class MenuService {
         menu.addCommand(new ShowBooks(new BookController(menuController)));
         menu.addCommand(new ReturnBook(new ReturnBookController(menuController)));
         menu.addCommand(new ShowAccounts(new AccountController(menuController)));
+        menu.addCommand(new RemoveAccount(new AccountController(menuController)));
     }
 
     public boolean executeCommand(String userInput) {


### PR DESCRIPTION
#### Issue
https://trello.com/c/AwWthCHM

### Description
This branch enables to remove a reader account

### Motivation
It is a crucial functionality for library personnel to be able to remove an account of the user

### Changes introduced by this pull request

- add class command to remove account
- add command `remove account` to the list of possible commands
- add interaction with user with warning that it cannot be rollback
- add logic to remove the account
- add handling exception if the account has not been found in db
- add methods in db: to remove the account and to check if account exist using `hibernate framework`

### Testing
- [x] account is deleted
- [x] abort operation works if user changed his mind
- [x] if account is not found in db app still runs and gives the message that this account does not exist in db  