### PR TITLE
fix of sorting with two-words command in show books feature

### DIFF
--- a/src/main/java/org/klodnicki/repository/BookRepository.java
+++ b/src/main/java/org/klodnicki/repository/BookRepository.java
@@ -72,13 +72,6 @@ public class BookRepository {
         return query.getResultList();
     }
 
-    public List<BookInfo> findAllBooks() {
-        String hqlQuery = "FROM BookInfo";
-        TypedQuery<BookInfo> query = entityManager.createQuery(hqlQuery, BookInfo.class);
-
-        return query.getResultList();
-    }
-
     public List<BookInfo> findBooksByAccount(Account account) {
         String hqlQuery = "FROM BookInfo b JOIN b.accounts a WHERE a.id = :idAccount";
         TypedQuery<BookInfo> query = entityManager.createQuery(hqlQuery, BookInfo.class);

--- a/src/main/java/org/klodnicki/service/BookService.java
+++ b/src/main/java/org/klodnicki/service/BookService.java
@@ -73,6 +73,15 @@ public class BookService {
         return bookRepository.findAllBooksSortByParameter(parameter);
     }
 
+    private String prepareParameterToDatabase(String parameter) {
+        for (SortOption sort : SortOption.values()) {
+            if (sort.getSortName().equalsIgnoreCase(parameter)) {
+                parameter = sort.getHqlParameter();
+            }
+        }
+        return parameter;
+    }
+
 
     public List<String> prepareListOfAllBooksSortByParameter(String parameter) throws NotFoundInDatabaseException,
             SortParameterNotFoundException {
@@ -83,7 +92,8 @@ public class BookService {
             throw new SortParameterNotFoundException();
         }
 
-        List<BookInfo> allBooksInDatabaseSortByParameter = getAllBooksFromDatabaseSortByParameter(parameter);
+        List<BookInfo> allBooksInDatabaseSortByParameter = getAllBooksFromDatabaseSortByParameter
+                (prepareParameterToDatabase(parameter));
         List<String> results = new ArrayList<>();
 
         if (allBooksInDatabaseSortByParameter.isEmpty()) {

--- a/src/main/java/org/klodnicki/service/BookService.java
+++ b/src/main/java/org/klodnicki/service/BookService.java
@@ -43,25 +43,6 @@ public class BookService {
         return bookRepository.findBooksByTitleAndAuthor(title, author);
     }
 
-    private List<BookInfo> getAllBooksFromDatabase() {
-        return bookRepository.findAllBooks();
-    }
-
-    public List<String> prepareListOfAllBooks() throws NotFoundInDatabaseException {
-        List<BookInfo> allBooksInDatabase = getAllBooksFromDatabase();
-        List<String> results = new ArrayList<>();
-
-        if (allBooksInDatabase.isEmpty()) {
-            throw new NotFoundInDatabaseException(BookInfo.class);
-        }
-
-        for (int i = 0; i < allBooksInDatabase.size(); i++) {
-            results.add(allBooksInDatabase.get(i).toString());
-        }
-
-        return results;
-    }
-
     private List<BookInfo> getBooksInfoFromDatabaseByAccount(Account account) {
         return bookRepository.findBooksByAccount(account);
     }

--- a/src/main/java/org/klodnicki/service/SortOption.java
+++ b/src/main/java/org/klodnicki/service/SortOption.java
@@ -1,24 +1,31 @@
 package org.klodnicki.service;
 
 public enum SortOption {
-    TITLE("title"),
-    AUTHOR("author"),
-    ISBN("isbn"),
-    PUBLISHER("publisher"),
-    PUBLICATION_YEAR("publication year"),
-    EDITION("edition"),
-    GENRE("genre"),
-    DESCRIPTION("description"),
-    LANGUAGE("language"),
-    COPIES_NUMBER("copies number");
+    TITLE("title", "title"),
+    AUTHOR("author", "author"),
+    ISBN("isbn", "isbn"),
+    PUBLISHER("publisher", "publisher"),
+    PUBLICATION_YEAR("publication year", "publicationYear"),
+    EDITION("edition", "edition"),
+    GENRE("genre", "genre"),
+    DESCRIPTION("description", "description"),
+    LANGUAGE("language", "language"),
+    COPIES_NUMBER("copies number", "copiesNumber");
 
     private final String sortName;
+    private final String hqlParameter;
 
-    SortOption(String sortName) {
+    SortOption(String sortName, String hqlParameter) {
         this.sortName = sortName;
+        this.hqlParameter = hqlParameter;
     }
+
 
     public String getSortName() {
         return sortName;
+    }
+
+    public String getHqlParameter() {
+        return hqlParameter;
     }
 }


### PR DESCRIPTION
#### Issue
https://trello.com/c/8x1Qudyd

### Description
Fix bug. There was a crash when user wanted to sort books by two-words command, for example: copies number.

### Motivation
It is not acceptable to have any bug in app.

### Changes introduced by this pull request:
add hql parameters in enum class
add getter to use these parameters in service class
add method to prepare parameter to database
delete methods which are not used any more
### Testing

- [x]  it is possible now to sort books by two-words command
- [x]  if the command has en error the message is shown and app still runs without any crash