### PR TITLE
fix of sorting with two-words command in show books feature

### DIFF
--- a/src/main/java/org/klodnicki/service/BookService.java
+++ b/src/main/java/org/klodnicki/service/BookService.java
@@ -73,24 +73,20 @@ public class BookService {
         return bookRepository.findAllBooksSortByParameter(parameter);
     }
 
-    private String prepareParameterToDatabase(String parameter) {
+    private String prepareParameterToDatabase(String parameter) throws SortParameterNotFoundException {
         for (SortOptionBookInfo sort : SortOptionBookInfo.values()) {
             if (sort.getSortName().equalsIgnoreCase(parameter)) {
-                parameter = sort.getHqlParameter();
+                return sort.getHqlParameter();
             }
         }
-        return parameter;
+        throw new SortParameterNotFoundException();
     }
-
-
+    
     public List<String> prepareListOfAllBooksSortByParameter(String parameter) throws NotFoundInDatabaseException,
             SortParameterNotFoundException {
         // enum z polami do sortowania
         // pętla po tym enumie
         // jeśli nie ma takiego enuma, to throw new SortParameterEx
-        if (!sortOptionValidation(parameter)) {
-            throw new SortParameterNotFoundException();
-        }
 
         List<BookInfo> allBooksInDatabaseSortByParameter = getAllBooksFromDatabaseSortByParameter
                 (prepareParameterToDatabase(parameter));
@@ -106,16 +102,6 @@ public class BookService {
         return results;
     }
 
-    private boolean sortOptionValidation(String parameter) {
-
-        for (SortOptionBookInfo sortOptionBookInfo : SortOptionBookInfo.values()) {
-            if (sortOptionBookInfo.getSortName().equalsIgnoreCase(parameter)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     public List<String> sortOptionNames() {
         List<String> namesList = new ArrayList<>();
         for (SortOptionBookInfo sortOptionBookInfo : SortOptionBookInfo.values()) {
@@ -123,5 +109,4 @@ public class BookService {
         }
         return namesList;
     }
-
 }

--- a/src/main/java/org/klodnicki/service/BookService.java
+++ b/src/main/java/org/klodnicki/service/BookService.java
@@ -74,7 +74,7 @@ public class BookService {
     }
 
     private String prepareParameterToDatabase(String parameter) {
-        for (SortOption sort : SortOption.values()) {
+        for (SortOptionBookInfo sort : SortOptionBookInfo.values()) {
             if (sort.getSortName().equalsIgnoreCase(parameter)) {
                 parameter = sort.getHqlParameter();
             }

--- a/src/main/java/org/klodnicki/service/BookService.java
+++ b/src/main/java/org/klodnicki/service/BookService.java
@@ -73,6 +73,15 @@ public class BookService {
         return bookRepository.findAllBooksSortByParameter(parameter);
     }
 
+    private String prepareParameterToDatabase(String parameter) {
+        for (SortOption sort : SortOption.values()) {
+            if (sort.getSortName().equalsIgnoreCase(parameter)) {
+                parameter = sort.getHqlParameter();
+            }
+        }
+        return parameter;
+    }
+
 
     public List<String> prepareListOfAllBooksSortByParameter(String parameter) throws NotFoundInDatabaseException,
             SortParameterNotFoundException {
@@ -83,7 +92,8 @@ public class BookService {
             throw new SortParameterNotFoundException();
         }
 
-        List<BookInfo> allBooksInDatabaseSortByParameter = getAllBooksFromDatabaseSortByParameter(parameter);
+        List<BookInfo> allBooksInDatabaseSortByParameter = getAllBooksFromDatabaseSortByParameter
+                (prepareParameterToDatabase(parameter));
         List<String> results = new ArrayList<>();
 
         if (allBooksInDatabaseSortByParameter.isEmpty()) {

--- a/src/main/java/org/klodnicki/service/SortOptionBookInfo.java
+++ b/src/main/java/org/klodnicki/service/SortOptionBookInfo.java
@@ -1,24 +1,31 @@
 package org.klodnicki.service;
 
 public enum SortOptionBookInfo {
-    TITLE("title"),
-    AUTHOR("author"),
-    ISBN("isbn"),
-    PUBLISHER("publisher"),
-    PUBLICATION_YEAR("publication year"),
-    EDITION("edition"),
-    GENRE("genre"),
-    DESCRIPTION("description"),
-    LANGUAGE("language"),
-    COPIES_NUMBER("copies number");
+    TITLE("title", "title"),
+    AUTHOR("author", "author"),
+    ISBN("isbn", "isbn"),
+    PUBLISHER("publisher", "publisher"),
+    PUBLICATION_YEAR("publication year", "publicationYear"),
+    EDITION("edition", "edition"),
+    GENRE("genre", "genre"),
+    DESCRIPTION("description", "description"),
+    LANGUAGE("language", "language"),
+    COPIES_NUMBER("copies number", "copiesNumber");
+
 
     private final String sortName;
+    private final String hqlParameter;
 
-    SortOptionBookInfo(String sortName) {
+    SortOptionBookInfo(String sortName, String hqlParameter) {
         this.sortName = sortName;
+        this.hqlParameter = hqlParameter;
     }
 
     public String getSortName() {
         return sortName;
+    }
+
+    public String getHqlParameter() {
+        return hqlParameter;
     }
 }


### PR DESCRIPTION
#### Issue
https://trello.com/c/8x1Qudyd

### Description
Fix bug. There was a crash when user wanted to sort books by two-words command, for example: copies number.

### Motivation
It is not acceptable to have any bug in app.

### Changes introduced by this pull request:

- add hql parameters in enum class
- add getter to use these parameters in service class
- add method to prepare parameter to database
- delete methods which are not used any more

Testing

- [x]  it is possible now to sort books by two-words command
- [x]  if the command has en error the message is shown and app still runs without any crash